### PR TITLE
Fixed deepseek problems with smart searcher

### DIFF
--- a/code_tests/low_cost_or_live_api_tests/test_smart_searcher.py
+++ b/code_tests/low_cost_or_live_api_tests/test_smart_searcher.py
@@ -15,6 +15,21 @@ async def test_ask_question_basic() -> None:
         num_searches_to_run=1,
         num_sites_per_search=3,
         use_brackets_around_citations=True,
+        use_advanced_filters=False,
+    )
+    question = "What is the recent news on SpaceX?"
+    report = await searcher.invoke(question)
+    logger.info(f"Report:\n{report}")
+    validate_search_report(report)
+
+
+async def test_ask_question_with_filters() -> None:
+    searcher = SmartSearcher(
+        include_works_cited_list=True,
+        num_searches_to_run=1,
+        num_sites_per_search=3,
+        use_brackets_around_citations=True,
+        use_advanced_filters=True,
     )
     question = "What is the recent news on SpaceX?"
     report = await searcher.invoke(question)
@@ -85,3 +100,20 @@ async def test_ask_question_empty_prompt() -> None:
     searcher = SmartSearcher()
     with pytest.raises(ValueError):
         await searcher.invoke("")
+
+
+@pytest.mark.skip(
+    "Deepseek just doesn't understand the prompt well. Not worth getting working now"
+)
+async def test_deepseek_works_with_smart_searcher() -> None:
+    searcher = SmartSearcher(
+        model="openrouter/deepseek/deepseek-r1",
+        include_works_cited_list=True,
+        num_searches_to_run=2,
+        num_sites_per_search=10,
+        use_advanced_filters=True,
+    )
+    question = "Please forecast the price of Bitcoin in December 2025"
+    report = await searcher.invoke(question)
+    logger.info(f"Report:\n{report}")
+    validate_search_report(report)

--- a/code_tests/unit_tests/test_ai_models/test_exa_searcher.py
+++ b/code_tests/unit_tests/test_ai_models/test_exa_searcher.py
@@ -1,0 +1,102 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from forecasting_tools.ai_models.exa_searcher import SearchInput
+
+
+def test_search_input_valid_times() -> None:
+    now = datetime.now(timezone.utc)
+    valid_input = SearchInput(
+        web_search_query="test",
+        highlight_query=None,
+        include_domains=[],
+        exclude_domains=[],
+        include_text=None,
+        start_published_date=now - timedelta(days=10),
+        end_published_date=now - timedelta(days=1),
+    )
+    assert valid_input.start_published_date is not None
+    assert valid_input.end_published_date is not None
+    assert valid_input.start_published_date < valid_input.end_published_date
+
+
+def test_search_input_invalid_times_start_after_end() -> None:
+    now = datetime.now(timezone.utc)
+    with pytest.raises(ValueError):
+        SearchInput(
+            web_search_query="test",
+            highlight_query=None,
+            include_domains=[],
+            exclude_domains=[],
+            include_text=None,
+            start_published_date=now,
+            end_published_date=now - timedelta(days=1),
+        )
+
+
+def test_search_input_invalid_times_start_in_future() -> None:
+    now = datetime.now(timezone.utc)
+    with pytest.raises(ValueError):
+        SearchInput(
+            web_search_query="test",
+            highlight_query=None,
+            include_domains=[],
+            exclude_domains=[],
+            include_text=None,
+            start_published_date=now + timedelta(days=2),
+            end_published_date=now + timedelta(days=3),
+        )
+
+
+def test_search_input_invalid_times_end_in_future() -> None:
+    now = datetime.now(timezone.utc)
+    with pytest.raises(ValueError):
+        SearchInput(
+            web_search_query="test",
+            highlight_query=None,
+            include_domains=[],
+            exclude_domains=[],
+            include_text=None,
+            start_published_date=now - timedelta(days=2),
+            end_published_date=now + timedelta(days=1),
+        )
+
+
+def test_search_input_valid_include_text() -> None:
+    valid_input = SearchInput(
+        web_search_query="test",
+        highlight_query=None,
+        include_domains=[],
+        exclude_domains=[],
+        include_text="one two three",
+        start_published_date=None,
+        end_published_date=None,
+    )
+    assert valid_input.include_text == "one two three"
+
+
+def test_search_input_invalid_include_text_too_many_words() -> None:
+    with pytest.raises(ValueError):
+        SearchInput(
+            web_search_query="test",
+            highlight_query=None,
+            include_domains=[],
+            exclude_domains=[],
+            include_text="one two three four five six",
+            start_published_date=None,
+            end_published_date=None,
+        )
+
+
+def test_search_input_invalid_include_text_too_few_words() -> None:
+    with pytest.raises(ValueError):
+        SearchInput(
+            web_search_query="test",
+            highlight_query=None,
+            include_domains=[],
+            exclude_domains=[],
+            include_text="",
+            start_published_date=None,
+            end_published_date=None,
+        )

--- a/forecasting_tools/ai_models/exa_searcher.py
+++ b/forecasting_tools/ai_models/exa_searcher.py
@@ -97,15 +97,15 @@ class SearchInput(BaseModel, Jsonable):
             raise ValueError("start_published_date must be before today")
         if end_date and end_date > now_utc:
             raise ValueError("end_published_date must be before today")
-        if start_date and (now_utc - start_date) <= timedelta(days=1):
+        if start_date and (now_utc - start_date) <= timedelta(hours=3):
             logger.warning(
-                "You are searching for results from within the last day. This may not return any results."
+                "You are searching for results from within the last 3 hours. This may not return any results."
             )
         return self
 
     @model_validator(mode="after")
     def validate_include_text(self: SearchInput) -> SearchInput:
-        if self.include_text:
+        if self.include_text is not None:
             num_words = len(self.include_text.split())
             if num_words < 1 or num_words > 5:
                 raise ValueError("include_text must be 1-5 words")

--- a/forecasting_tools/ai_models/exa_searcher.py
+++ b/forecasting_tools/ai_models/exa_searcher.py
@@ -5,7 +5,7 @@ import os
 from datetime import datetime
 
 import aiohttp
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from forecasting_tools.ai_models.model_interfaces.incurs_cost import IncursCost
 from forecasting_tools.ai_models.model_interfaces.request_limited_model import (
@@ -75,6 +75,29 @@ class SearchInput(BaseModel, Jsonable):
         description="The latest publication date for search results"
     )
 
+    @model_validator(mode="after")
+    def validate_times(self: SearchInput) -> SearchInput:
+        start_date = self.start_published_date
+        end_date = self.end_published_date
+        today = datetime.now()
+        if start_date and end_date and start_date > end_date:
+            raise ValueError(
+                "start_published_date must be before or equal to end_published_date"
+            )
+        if start_date and start_date > today:
+            raise ValueError("start_published_date must be before today")
+        if end_date and end_date > today:
+            raise ValueError("end_published_date must be before today")
+        return self
+
+    @model_validator(mode="after")
+    def validate_include_text(self: SearchInput) -> SearchInput:
+        if self.include_text:
+            num_words = len(self.include_text.split())
+            if num_words < 1 or num_words > 5:
+                raise ValueError("include_text must be 1-5 words")
+        return self
+
 
 class ExaSearcher(
     RequestLimitedModel, RetryableModel, TimeLimitedModel, IncursCost
@@ -129,7 +152,7 @@ class ExaSearcher(
         self, search_query_or_strategy: str | SearchInput
     ) -> list[ExaSource]:
         if isinstance(search_query_or_strategy, str):
-            search_strategy = self.__get_default_search_strategy(
+            search_strategy = self.string_to_default_search_input(
                 search_query_or_strategy
             )
         else:
@@ -211,7 +234,7 @@ class ExaSearcher(
         return url, headers, payload
 
     @classmethod
-    def __get_default_search_strategy(cls, search_query: str) -> SearchInput:
+    def string_to_default_search_input(cls, search_query: str) -> SearchInput:
         return SearchInput(
             web_search_query=search_query,
             highlight_query=search_query,
@@ -322,7 +345,7 @@ class ExaSearcher(
     @classmethod
     def _get_cheap_input_for_invoke(cls) -> SearchInput:
         search_query = "Latest news on AI Research Tools"
-        return cls.__get_default_search_strategy(search_query)
+        return cls.string_to_default_search_input(search_query)
 
 
 # Example response from Exa API: (see the Exa playground for more examples)

--- a/forecasting_tools/forecast_bots/official_bots/q2_template_bot.py
+++ b/forecasting_tools/forecast_bots/official_bots/q2_template_bot.py
@@ -104,6 +104,7 @@ class Q2TemplateBot2025(ForecastBot):
                     temperature=0,
                     num_searches_to_run=2,
                     num_sites_per_search=10,
+                    use_advanced_filters=False,
                 )
                 research = await searcher.invoke(prompt)
             elif not researcher or researcher == "None":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forecasting-tools"
-version = "0.2.35"
+version = "0.2.36"
 description = "AI forecasting and research tools to help humans reason about and forecast the future"
 authors = ["Benjamin Wilson <mokoresearch@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Added ability to set smart searcher mode to not use the advanced filters. Deepseek had a lot of trouble creating correct search filters. I also set the default to not use advanced search filters since it seems it probably confuses the model generally.