### PR TITLE
Fix/post_binary_question_prediction range

### DIFF
--- a/forecasting_tools/helpers/metaculus_api.py
+++ b/forecasting_tools/helpers/metaculus_api.py
@@ -146,8 +146,8 @@ class MetaculusApi:
         cls, question_id: int, prediction_in_decimal: float
     ) -> None:
         logger.info(f"Posting prediction on question {question_id}")
-        if prediction_in_decimal < 0.01 or prediction_in_decimal > 0.99:
-            raise ValueError("Prediction value must be between 0.001 and 0.99")
+        if prediction_in_decimal < 0.001 or prediction_in_decimal > 0.999:
+            raise ValueError("Prediction value must be between 0.001 and 0.999")
         payload = {
             "probability_yes": prediction_in_decimal,
         }


### PR DESCRIPTION
The binary prediction minimum / maximum values are set [here](https://github.com/Metaculus/metaculus/blob/0922215454506c19d90a3e1d5b365420363f6685/front_end/src/components/comment_feed/comment_cmm.tsx#L30C14-L31) to .001 / .999. In the below method an error was thrown for binary predictions < .01. 