### PR TITLE
fix: Add a rate limit to the asknews calls

### DIFF
--- a/forecasting_tools/helpers/asknews_searcher.py
+++ b/forecasting_tools/helpers/asknews_searcher.py
@@ -23,9 +23,11 @@ except ImportError:
 
 
 class AskNewsSearcher:
-    _default_search_depth = 2
-    _default_max_depth = 2
+    _default_search_depth = 1
+    _default_max_depth = 1
     _default_model = "deepseek-basic"
+    _default_sources = ["asknews"]
+    _default_rate_limit = 12
 
     def __init__(
         self,
@@ -59,6 +61,8 @@ class AskNewsSearcher:
                 return_type="both",
                 strategy="latest news",  # enforces looking at the latest news only
             )
+
+            await asyncio.sleep(self._default_rate_limit)  # free tier AskNews has a ratelimit of 1 call per 10 seconds
 
             # get context from the "historical" database that contains a news archive going back to 2023
             historical_response = await ask.news.search_news(
@@ -107,7 +111,7 @@ class AskNewsSearcher:
         if "asknews/deep-research/low-depth" in preset:
             research = await self.get_formatted_deep_research(
                 prompt,
-                sources=["asknews", "google", "x", "wiki"],
+                sources=self._default_sources,
                 search_depth=1,
                 max_depth=1,
                 model=model_name,
@@ -116,6 +120,7 @@ class AskNewsSearcher:
             research = await self.get_formatted_deep_research(
                 prompt,
                 sources=["asknews", "google", "x", "wiki"],
+                filter_params={"premium": True},
                 search_depth=2,
                 max_depth=4,
                 model=model_name,
@@ -124,6 +129,7 @@ class AskNewsSearcher:
             research = await self.get_formatted_deep_research(
                 prompt,
                 sources=["asknews", "google", "x", "wiki"],
+                filter_params={"premium": True},
                 search_depth=4,
                 max_depth=6,
                 model=model_name,
@@ -142,9 +148,10 @@ class AskNewsSearcher:
         ) = _default_model,
         search_depth: int = _default_search_depth,
         max_depth: int = _default_max_depth,
+        filter_params: dict[str, bool] | None = None,
     ) -> str:
         response = await self.run_deep_research(
-            query, sources, model, search_depth, max_depth
+            query, sources, model, search_depth, max_depth, filter_params
         )
         text = response.choices[0].message.content
 
@@ -170,6 +177,7 @@ class AskNewsSearcher:
         ) = _default_model,
         search_depth: int = _default_search_depth,
         max_depth: int = _default_max_depth,
+        filter_params: dict[str, bool] | None = None,
     ) -> CreateDeepNewsResponse:
         try:
             from asknews_sdk.dto.deepnews import CreateDeepNewsResponse
@@ -191,6 +199,7 @@ class AskNewsSearcher:
                 return_sources=False,
                 model=model,
                 inline_citations="numbered",
+                filter_params=filter_params
             )
             if not isinstance(response, CreateDeepNewsResponse):
                 raise ValueError("Response is not a CreateDeepNewsResponse")


### PR DESCRIPTION
The Metaculus data access has a rate limit of 1 concurrent request and 1 per second (burst, 1 per 10 seconds on average). 

It means that technically, two calls can be made with 1 second delay between one another. A subsequent call would need to wait 10 seconds before trying again. 

We add a delay of 12 seconds between the calls to ensure that the user never hits any rate limits. If a user wants to work with burst limiting, they need to use the response objects from AskNews, which contain headers indicating their burst rate allowances at any given moment in time.