### PR TITLE
fix: Add ASKNEWS_API_KEY support for asknews searcher

### DIFF
--- a/forecasting_tools/helpers/asknews_searcher.py
+++ b/forecasting_tools/helpers/asknews_searcher.py
@@ -87,7 +87,7 @@ class AskNewsSearcher:
 
             await asyncio.sleep(
                 self._default_rate_limit
-            )  # free tier AskNews Free tier has a ratelimit of 1 call per 10 seconds
+            )  # AskNews free tier has a ratelimit of 1 call per 10 seconds
 
             # get context from the "historical" database that contains a news archive going back to 2023
             historical_response = await ask.news.search_news(


### PR DESCRIPTION
AskNews has added better support for API keys as opposed to client credentials. While both methods will always be supported - we are moving new users to API keys.

