### PR TITLE
remove GeneralLlm initialization from method definition to suppress cost warning

### DIFF
--- a/forecasting_tools/agents_and_tools/question_generators/question_decomposer.py
+++ b/forecasting_tools/agents_and_tools/question_generators/question_decomposer.py
@@ -170,10 +170,12 @@ class QuestionDecomposer:
         related_research: str | None,
         additional_context: str | None,
         number_of_questions: int = 5,
-        model: str | GeneralLlm = GeneralLlm.search_context_model(
-            "openrouter/perplexity/sonar"
-        ),
+        model: str | GeneralLlm | None = None,
     ) -> DecompositionResult:
+        if model is None:
+            model = GeneralLlm.search_context_model(
+                "openrouter/perplexity/sonar"
+            )
         llm = GeneralLlm.to_llm(model)
 
         prompt = clean_indents(


### PR DESCRIPTION
very quick PR to remove initialized class in method definition - pushing it off to method call
This suppresses cost estimation warning on import.

I made a quick pass at reducing total module load time when importing anything. I could get it down from 4.5 to 2.7 seconds by turning top level imports `forecasting_tools/__init__.py` into lazy imports. This avoided initializing some deprecated and likely-not-always-used files with heavy dependencies like scipy etc. This loses a bit of the click-through IDE support and I don't know the prioritization of keeping that so I left it well enough alone.
The 2.7 seconds left was pretty much entirely the `litellm` importing which is more annoying to circumnavigate because it's required for ?all? bots so I expect it to pretty much always want to be imported when you do anything in this codebase. The solution here could be to only import all the litellm packages the first time a bot gets initialized. This backloads the load time to execution time.

I do think the ultimate solution will be to move the locations of the submodules outside of the forecasting_tools folder so it doesn't run the `forecasting_tools/__init__.py` file unless you specifically do something like `from forecasting_tools import <blah>`. (when you do something like `from forecasting_tools.forecast_bots.template_bot import TemplateBot` it will run (if they exist) the `forecasting_tools/__init__.py` and `forecasting_tools/forecast_bots/__init__.py` which means you currently import EVERYTHING when you import anything).