### PR TITLE
Fix/several bot failures

### DIFF
--- a/.github/workflows/run-bot-aib-tournament.yaml
+++ b/.github/workflows/run-bot-aib-tournament.yaml
@@ -1521,7 +1521,7 @@ jobs:
       bot_name: "METAC_UNIFORM_PROBABILITY_BOT_TOKEN"
       cache_key: asknews-cache-${{ github.run_id }}
     secrets:
-      INPUT_METACULUS_TOKENS: ${{ secrets.METACULUS_TOKENS }}
+      INPUT_METACULUS_TOKEN: ${{ secrets.METACULUS_TOKEN }}
       INPUT_METACULUS_API_BASE_URL: ${{ secrets.METACULUS_API_BASE_URL }}
       INPUT_ASKNEWS_CLIENT_ID: ${{ secrets.ASKNEWS_CLIENT_ID }}
       INPUT_ASKNEWS_SECRET: ${{ secrets.ASKNEWS_SECRET }}

--- a/.github/workflows/run-bot-aib-tournament.yaml
+++ b/.github/workflows/run-bot-aib-tournament.yaml
@@ -86,32 +86,6 @@ jobs:
 
   # NOTE: don't remove any of the open source models, since these are the best option for a long term baseline (other models get deprecated)
 
-  bot_grok_4_1_high: # TODO: Not yet released via API as of Dec 21st, 2025
-    needs: precache_asknews
-    uses: ./.github/workflows/run-bot-launcher.yaml
-    with:
-      bot_name: "METAC_GROK_4_1_HIGH"
-      cache_key: asknews-cache-${{ github.run_id }}
-    secrets:
-      INPUT_METACULUS_TOKEN: ${{ secrets.METAC_GROK_4_1_HIGH }}
-      INPUT_XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-      INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-      INPUT_ASKNEWS_CLIENT_ID: ${{ secrets.ASKNEWS_CLIENT_ID }}
-      INPUT_ASKNEWS_SECRET: ${{ secrets.ASKNEWS_SECRET }}
-
-  bot_grok_4_1: # TODO: Not yet released via API as of Dec 21st, 2025
-    needs: precache_asknews
-    uses: ./.github/workflows/run-bot-launcher.yaml
-    with:
-      bot_name: "METAC_GROK_4_1"
-      cache_key: asknews-cache-${{ github.run_id }}
-    secrets:
-      INPUT_METACULUS_TOKEN: ${{ secrets.METAC_GROK_4_1 }}
-      INPUT_XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-      INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-      INPUT_ASKNEWS_CLIENT_ID: ${{ secrets.ASKNEWS_CLIENT_ID }}
-      INPUT_ASKNEWS_SECRET: ${{ secrets.ASKNEWS_SECRET }}
-
   #################################### February 2026 new bots ####################################
 
   bot_claude_opus_4_6_high_32k:


### PR DESCRIPTION
3 bots were failing after changes made in #245 / #246. Two of the bots were Grok 4.1 since it is actually called 4.1 fast in the xAI / OpenRouter API. The last one was the uniform bot which doesn't actually make any model calls, so it doesn't have a name that corresponds to a token in the METACULUS_TOKENS json list.