### PR TITLE
fix: handle missing highlightScores from Exa API

### DIFF
--- a/code_tests/integration_tests/test_ai_models/test_exa_model.py
+++ b/code_tests/integration_tests/test_ai_models/test_exa_model.py
@@ -70,6 +70,35 @@ async def test_invoke_for_highlights_in_relevance_order(mocker: Mock) -> None:
         ), f"Highlights not in descending order at index {i}"
 
 
+async def test_invoke_for_highlights_with_missing_scores(mocker: Mock) -> None:
+    mock_return_value = [
+        ExaSource(
+            original_query="test query",
+            auto_prompt_string=None,
+            title="Test Title",
+            url="https://example.com",
+            text="Test text",
+            author=None,
+            published_date=None,
+            score=0.9,
+            highlights=["Highlight A", "Highlight B"],
+            highlight_scores=[],
+        ),
+    ]
+    AiModelMockManager.mock_ai_model_direct_call_with_value(
+        mocker, ExaSearcher, mock_return_value
+    )
+
+    searcher = ExaSearcher()
+    cheap_input = searcher._get_cheap_input_for_invoke()
+    result = await searcher.invoke_for_highlights_in_relevance_order(cheap_input)
+
+    assert len(result) == 2
+    for quote in result:
+        assert isinstance(quote, ExaHighlightQuote)
+        assert quote.score == 1.0
+
+
 async def test_general_invoke() -> None:
     num_results = 2
     model = ExaSearcher(

--- a/forecasting_tools/ai_models/exa_searcher.py
+++ b/forecasting_tools/ai_models/exa_searcher.py
@@ -144,7 +144,8 @@ class ExaSearcher(RequestLimitedModel, RetryableModel, TimeLimitedModel, IncursC
         sources = await self.invoke(search_query_or_strategy)
         all_highlights = []
         for source in sources:
-            for highlight, score in zip(source.highlights, source.highlight_scores):
+            scores = source.highlight_scores or [1.0] * len(source.highlights)
+            for highlight, score in zip(source.highlights, scores):
                 all_highlights.append(
                     ExaHighlightQuote(
                         highlight_text=highlight, score=score, source=source


### PR DESCRIPTION
## Summary

The Exa API has stopped returning `highlightScores` alongside `highlights` in some responses. The current code iterates using `zip(source.highlights, source.highlight_scores)`, which silently yields nothing when `highlight_scores` is an empty list — causing all highlights to be dropped even when the API returns valid content.

**Observed behavior:** 10 sources returned, 0 quotes collected, final output: `"No search results found for the query using the search filter chosen"`.

**Fix:** Default missing scores to `1.0` per highlight when the scores array is empty.

```python
# Before
for highlight, score in zip(source.highlights, source.highlight_scores):

# After
scores = source.highlight_scores or [1.0] * len(source.highlights)
for highlight, score in zip(source.highlights, scores):
```

I verified the fix by inspecting raw Exa API responses and confirming `highlightScores` is returned as `[]` while `highlights` contains valid content. A test case covering the empty `highlightScores` fallback has been added to `test_exa_model.py`.