### PR TITLE
Disable muse-spark bots and mask derived Metaculus tokens

### DIFF
--- a/.github/workflows/run-bot-aib-tournament.yaml
+++ b/.github/workflows/run-bot-aib-tournament.yaml
@@ -117,20 +117,6 @@ jobs:
       INPUT_ASKNEWS_CLIENT_ID: ${{ secrets.ASKNEWS_CLIENT_ID }}
       INPUT_ASKNEWS_SECRET: ${{ secrets.ASKNEWS_SECRET }}
 
-  bot_muse_spark_1_3:
-    needs: precache_asknews
-    uses: ./.github/workflows/run-bot-launcher.yaml
-    with:
-      bot_name: "METAC_MUSE_SPARK_1_3"
-      metac_name: "metac-muse-spark-1-3+asknews"
-      cache_key: asknews-cache-${{ github.run_id }}
-    secrets:
-      INPUT_METACULUS_TOKENS: ${{ secrets.METACULUS_TOKENS }}
-      INPUT_METACULUS_API_BASE_URL: ${{ secrets.METACULUS_API_BASE_URL }}
-      INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-      INPUT_ASKNEWS_CLIENT_ID: ${{ secrets.ASKNEWS_CLIENT_ID }}
-      INPUT_ASKNEWS_SECRET: ${{ secrets.ASKNEWS_SECRET }}
-
   bot_claude_fable_5_1:
     needs: precache_asknews
     uses: ./.github/workflows/run-bot-launcher.yaml
@@ -247,20 +233,6 @@ jobs:
       INPUT_ASKNEWS_CLIENT_ID: ${{ secrets.ASKNEWS_CLIENT_ID }}
       INPUT_ASKNEWS_SECRET: ${{ secrets.ASKNEWS_SECRET }}
 
-  bot_muse_spark_1_2:
-    needs: precache_asknews
-    uses: ./.github/workflows/run-bot-launcher.yaml
-    with:
-      bot_name: "METAC_MUSE_SPARK_1_2"
-      metac_name: "metac-muse-spark-1-2+asknews"
-      cache_key: asknews-cache-${{ github.run_id }}
-    secrets:
-      INPUT_METACULUS_TOKENS: ${{ secrets.METACULUS_TOKENS }}
-      INPUT_METACULUS_API_BASE_URL: ${{ secrets.METACULUS_API_BASE_URL }}
-      INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-      INPUT_ASKNEWS_CLIENT_ID: ${{ secrets.ASKNEWS_CLIENT_ID }}
-      INPUT_ASKNEWS_SECRET: ${{ secrets.ASKNEWS_SECRET }}
-
   bot_qwen_3_8_max:
     needs: precache_asknews
     uses: ./.github/workflows/run-bot-launcher.yaml
@@ -354,20 +326,6 @@ jobs:
     with:
       bot_name: "METAC_INKLING"
       metac_name: "metac-inkling+asknews"
-      cache_key: asknews-cache-${{ github.run_id }}
-    secrets:
-      INPUT_METACULUS_TOKENS: ${{ secrets.METACULUS_TOKENS }}
-      INPUT_METACULUS_API_BASE_URL: ${{ secrets.METACULUS_API_BASE_URL }}
-      INPUT_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-      INPUT_ASKNEWS_CLIENT_ID: ${{ secrets.ASKNEWS_CLIENT_ID }}
-      INPUT_ASKNEWS_SECRET: ${{ secrets.ASKNEWS_SECRET }}
-
-  bot_muse_spark_1_1:
-    needs: precache_asknews
-    uses: ./.github/workflows/run-bot-launcher.yaml
-    with:
-      bot_name: "METAC_MUSE_SPARK_1_1"
-      metac_name: "metac-muse-spark-1-1+asknews"
       cache_key: asknews-cache-${{ github.run_id }}
     secrets:
       INPUT_METACULUS_TOKENS: ${{ secrets.METACULUS_TOKENS }}

--- a/.github/workflows/run-bot-launcher.yaml
+++ b/.github/workflows/run-bot-launcher.yaml
@@ -121,6 +121,7 @@ jobs:
       - name: Resolve METACULUS_TOKEN
         run: |
           if [ -n "$RAW_TOKEN" ]; then
+            echo "::add-mask::$RAW_TOKEN"
             echo "METACULUS_TOKEN=$RAW_TOKEN" >> $GITHUB_ENV
           else
             TOKEN=$(echo "$METACULUS_TOKENS" | jq -r --arg key "$METAC_NAME" '.[$key] // empty')
@@ -128,6 +129,9 @@ jobs:
               echo "ERROR: No token found for $METAC_NAME in METACULUS_TOKENS" >&2
               exit 1
             fi
+            # Tokens pulled out of the METACULUS_TOKENS json are not registered secrets,
+            # so without this they get printed in plain text by later steps
+            echo "::add-mask::$TOKEN"
             echo "METACULUS_TOKEN=$TOKEN" >> $GITHUB_ENV
           fi
         env:

--- a/code_tests/unit_tests/test_ai_models/test_general_llm.py
+++ b/code_tests/unit_tests/test_ai_models/test_general_llm.py
@@ -1,0 +1,75 @@
+import pytest
+from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+from forecasting_tools.ai_models.general_llm import GeneralLlm
+
+MUSE_SPARK_MODEL = "openrouter/meta/muse-spark-1.1"
+
+
+def _model_response(
+    content: str | None, reasoning_content: str | None = None
+) -> ModelResponse:
+    response = ModelResponse(
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(
+                    content=content,
+                    role="assistant",
+                    reasoning_content=reasoning_content,
+                ),
+            )
+        ],
+    )
+    response.usage = Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)  # type: ignore
+    return response
+
+
+def _llm_returning(
+    monkeypatch: pytest.MonkeyPatch, response: ModelResponse
+) -> GeneralLlm:
+    llm = GeneralLlm(model=MUSE_SPARK_MODEL, temperature=0.3, allowed_tries=1)
+
+    async def fake_call(prompt: str) -> ModelResponse:
+        return response
+
+    monkeypatch.setattr(llm, "_call_litellm_dropping_deprecated_temperature", fake_call)
+    return llm
+
+
+async def test_error_names_model_and_finish_reason_when_nothing_is_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm = _llm_returning(monkeypatch, _model_response(content=None))
+
+    with pytest.raises(RuntimeError) as error:
+        await llm.invoke("Whats 2+2?")
+
+    error_message = str(error.value)
+    assert MUSE_SPARK_MODEL in error_message
+    assert "stop" in error_message
+    assert "no text" in error_message
+
+
+async def test_reasoning_content_is_used_when_content_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm = _llm_returning(
+        monkeypatch,
+        _model_response(content=None, reasoning_content="The answer is 4"),
+    )
+
+    answer = await llm.invoke("Whats 2+2?")
+
+    assert answer == "The answer is 4"
+
+
+async def test_normal_content_is_returned_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm = _llm_returning(monkeypatch, _model_response(content="4"))
+
+    answer = await llm.invoke("Whats 2+2?")
+
+    assert answer == "4"

--- a/forecasting_tools/ai_models/general_llm.py
+++ b/forecasting_tools/ai_models/general_llm.py
@@ -280,9 +280,12 @@ class GeneralLlm(
         if answer is None:
             answer = self._answer_from_reasoning_content(message)
         finish_reason = choices[0].finish_reason
-        assert isinstance(
-            answer, str
-        ), f"Answer is not a string and is of type: {type(answer)}. Answer: {answer}. Finish reason: {finish_reason}"
+        if not isinstance(answer, str):
+            raise RuntimeError(
+                "LLM returned no text in either the content or the reasoning content field. "
+                f"The model was {self.model}, the content was {answer} (type {type(answer)}), "
+                f"the finish reason was {finish_reason}, and the usage was {response.usage}."
+            )
         usage = response.usage  # type: ignore
         assert isinstance(usage, Usage)
         prompt_tokens = usage.prompt_tokens

--- a/run_bots.py
+++ b/run_bots.py
@@ -650,7 +650,7 @@ def get_default_bot_dict() -> dict[str, RunBotConfig]:  # NOSONAR
                     temperature=default_temperature,
                 ),
             ),
-            "tournaments": TournConfig.aib_and_site,
+            "tournaments": TournConfig.NONE,  # Returns empty completions via OpenRouter as of Sep 8th, 2026
         },
         "METAC_CLAUDE_FABLE_5_1": {
             "estimated_cost_per_question": roughly_opus_4_5_cost * 2,
@@ -742,7 +742,7 @@ def get_default_bot_dict() -> dict[str, RunBotConfig]:  # NOSONAR
                     temperature=default_temperature,
                 ),
             ),
-            "tournaments": TournConfig.aib_and_site,
+            "tournaments": TournConfig.NONE,  # Returns empty completions via OpenRouter as of Sep 8th, 2026
         },
         "METAC_QWEN_3_8_MAX": {
             "estimated_cost_per_question": roughly_gpt_5_cost * 0.6,
@@ -826,7 +826,7 @@ def get_default_bot_dict() -> dict[str, RunBotConfig]:  # NOSONAR
                     temperature=default_temperature,
                 ),
             ),
-            "tournaments": TournConfig.aib_and_site,
+            "tournaments": TournConfig.NONE,  # Returns empty completions via OpenRouter as of Sep 8th, 2026
         },
         "METAC_KIMI_K3": {
             "estimated_cost_per_question": roughly_gpt_5_cost * 1.5,


### PR DESCRIPTION
## Why

`muse_spark_1_1`, `1_2` and `1_3` have produced zero forecasts across the Fall 2026 season questions (45526–45569), and were the cause of most AIB workflow failures since Sept 7.

Their passing runs were runs with `Questions to forecast: 0`, which is why this was not visible during the Sept 2–6 gap between seasons.

## Root cause

OpenRouter returns HTTP 200 with an empty completion for all three models:

```json
{"choices":[{"finish_reason":"stop","native_finish_reason":"completed",
  "message":{"role":"assistant","content":null,"refusal":null,"reasoning":null}}]}
```

`content` and `reasoning` are both null and there is no `usage` block. This reproduces on any prompt, with and without `temperature`, `include_reasoning` and `reasoning_effort`, so there is no text for the client to read. `/models/meta/muse-spark-1.1/endpoints` lists a single provider, so provider routing is not an option either. `muse-glimmer-30b` is served by a different provider and is unaffected.

The three bots are disabled following the existing convention (`TournConfig.NONE` plus removing the workflow job), which keeps enabled bots (83) matched 1:1 with workflow jobs (83).

## Workflow token handling

The launcher extracts a single token from the `METACULUS_TOKENS` secret with `jq`. A value derived from a secret is a new string that Actions does not treat as masked, so it could be written to logs by later steps. This registers it with `::add-mask::` before use.

## Error message

The failure surfaced as `AssertionError: Answer is not a string and is of type: NoneType`, which did not distinguish an upstream provider fault from a parsing bug. It now reports the model, the finish reason and the usage.

## Testing

- 3 new unit tests in `code_tests/unit_tests/test_ai_models/test_general_llm.py` covering the empty response, the reasoning-content fallback and the normal path.
- Full unit suite: 927 passed. The 14 failures are pre-existing and reproduce identically on `main`; they pass when run file-alone, so they are order-dependent.
- black / isort / ruff / typos pass at the pinned pre-commit versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)