### PR TITLE
Switch DeepNews bot to claude-fable-5-1

### DIFF
--- a/code_tests/integration_tests/test_asknews.py
+++ b/code_tests/integration_tests/test_asknews.py
@@ -56,3 +56,20 @@ async def test_deep_research_accepts_podcasts_source() -> None:
     logger.info(f"Deep research with podcasts source: {content}")
     assert content is not None, "Content is None"
     assert len(content) > 100, "Content is too short"
+
+
+async def test_deep_research_accepts_claude_fable_5_1_model() -> None:
+    if not os.getenv("ASKNEWS_CLIENT_ID") or not os.getenv("ASKNEWS_SECRET"):
+        pytest.skip("ASKNEWS_CLIENT_ID or ASKNEWS_SECRET is not set")
+    response = await AskNewsSearcher().run_deep_research(
+        "In one sentence, what is the latest news about the US federal funds rate?",
+        sources=["asknews"],
+        model="claude-fable-5-1",
+        search_depth=1,
+        max_depth=1,
+    )
+    content = response.choices[0].message.content
+    logger.info(f"Deep research with claude-fable-5-1: {content}")
+    assert response.model == "claude-fable-5-1", f"Unexpected model: {response.model}"
+    assert content is not None, "Content is None"
+    assert len(content) > 100, "Content is too short"

--- a/run_bots.py
+++ b/run_bots.py
@@ -505,7 +505,7 @@ def get_default_bot_dict() -> dict[str, RunBotConfig]:  # NOSONAR
     sonnet_4_5_name = "anthropic/claude-sonnet-4-5-20250929"
     gemini_2_5_pro = "openrouter/google/gemini-2.5-pro"  # Used to be gemini-2.5-pro-preview (though automatically switched to regular pro when preview was deprecated)
     gemini_default_timeout = 5 * 60
-    deepnews_model = "asknews/deep-research/high-depth/claude-fable-5"  # Switched to claude-fable-5 and added podcasts source Sep 5th 2026. Switched to opus 4.6 Feb 23rd. Switched to high depth Feb 16th 2026. Switched from claude-sonnet-4-20250514 to sonnet 4.5 in Nov 2025. Switched from high to medium depth on Jan 2nd, 2026
+    deepnews_model = "asknews/deep-research/high-depth/claude-fable-5-1"  # Switched to claude-fable-5-1 Sep 8th 2026 once AskNews supported it. Switched to claude-fable-5 and added podcasts source Sep 5th 2026. Switched to opus 4.6 Feb 23rd. Switched to high depth Feb 16th 2026. Switched from claude-sonnet-4-20250514 to sonnet 4.5 in Nov 2025. Switched from high to medium depth on Jan 2nd, 2026
 
     roughly_sonnet_4_cost = 0.25190
     roughly_gpt_5_high_cost = 0.37868


### PR DESCRIPTION
## What changed

- `METAC_ASKNEWS_DEEPNEWS` (research-only DeepNews bot) now uses `asknews/deep-research/high-depth/claude-fable-5-1` instead of `claude-fable-5`.
- Added a cheap low-depth integration test in `code_tests/integration_tests/test_asknews.py` that asserts AskNews accepts the `claude-fable-5-1` model and reports it back in the response.

## Why

When the bot was moved to `claude-fable-5` on Sep 5th 2026 (#336), AskNews did not yet accept `claude-fable-5-1`. It does now, so the bot is being moved to the newer model.

## Reviewer notes

- Verified live on Sep 8th 2026: a low-depth call (~18s) and the full high-depth production preset with the podcasts source (~83s) both returned clean formatted output with no stray `<final_answer>` / `<think>` tags and `response.model == "claude-fable-5-1"`.
- `gpt-6-astra` also works on the AskNews server now (the rollout issue noted in #336 is resolved), but `claude-fable-5-1` was chosen.
- The asknews SDK 0.14.2 `DeepNewsModel` Literal does not list `claude-fable-5-1` yet. The SDK does not validate the value at runtime and `AskNewsSearcher` accepts a plain `str`, so this works today with no SDK change.
- `code_tests/unit_tests/test_run_bots.py` and pre-commit (black, isort, ruff, typos) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)