### PR TITLE
Mask derived Metaculus token in Actions logs

### DIFF
--- a/.github/workflows/run-bot-launcher.yaml
+++ b/.github/workflows/run-bot-launcher.yaml
@@ -121,6 +121,7 @@ jobs:
       - name: Resolve METACULUS_TOKEN
         run: |
           if [ -n "$RAW_TOKEN" ]; then
+            echo "::add-mask::$RAW_TOKEN"
             echo "METACULUS_TOKEN=$RAW_TOKEN" >> $GITHUB_ENV
           else
             TOKEN=$(echo "$METACULUS_TOKENS" | jq -r --arg key "$METAC_NAME" '.[$key] // empty')
@@ -128,6 +129,7 @@ jobs:
               echo "ERROR: No token found for $METAC_NAME in METACULUS_TOKENS" >&2
               exit 1
             fi
+            echo "::add-mask::$TOKEN"
             echo "METACULUS_TOKEN=$TOKEN" >> $GITHUB_ENV
           fi
         env:


### PR DESCRIPTION
## What

The `Resolve METACULUS_TOKEN` step in `run-bot-launcher.yaml` derives a per-bot token from the `METACULUS_TOKENS` secret (via `jq`) and writes it to `$GITHUB_ENV`. GitHub Actions masks only the exact strings registered as secrets, so a value *derived* from a secret — parsed out of the JSON blob — is not on the mask list and can appear in later step logs.

This adds `::add-mask::` to register the resolved token before it is used, on both resolution branches, so it is redacted in subsequent output.

## Why it matters

Masking is not inherited: any value derived from a secret (parsed, decoded, sliced, concatenated) is unmasked until explicitly registered. Registering the derived value is the standard fix.

## Notes

- Change is confined to the one step that derives a secret before use; the caller workflow passes only registered secrets directly.
- Verified with the repo's pre-commit hooks (`check-yaml`, etc.).